### PR TITLE
#1 セッションストアのテスト修正

### DIFF
--- a/src/test/java/nablarch/fw/web/NewWebHandlerQueueIntegrationTest.java
+++ b/src/test/java/nablarch/fw/web/NewWebHandlerQueueIntegrationTest.java
@@ -48,6 +48,12 @@ public class NewWebHandlerQueueIntegrationTest extends WebHandlerQueueIntegratio
     @Test
     @RunAsClient
     public void testMultipart_session() throws Exception {
+        // NABLARCH_SIDやJSESSIONIDを生成するため、リクエストを送信
+        HttpRequest request = httpTransport.createRequestFactory()
+                .buildGetRequest(new GenericUrl(new URL(baseUrl, "action/MultipartAction/PutSession")));
+        HttpResponse response = request.execute();
+
+        // アップロードするファイルを作る
         File file = folder.newFile("multipart.txt");
 
         // hiddenStoreのパラメータを設定
@@ -56,10 +62,10 @@ public class NewWebHandlerQueueIntegrationTest extends WebHandlerQueueIntegratio
         part.setHeaders(new HttpHeaders().set("Content-Disposition", String.format("form-data; name=\"%s\"", "_HIDDEN_STORE_")));
         content.addPart(part);
 
-        HttpRequest request = httpTransport.createRequestFactory()
+        request = httpTransport.createRequestFactory()
                 .buildPostRequest(new GenericUrl(new URL(baseUrl, "action/MultipartAction/GetSession")), content);
-        request.getHeaders().setCookie("NABLARCH_SID=1234568d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92");
-        HttpResponse response = request.execute();
+        request.getHeaders().set("Cookie", response.getHeaders().get("Set-Cookie"));
+        response = request.execute();
 
         assertThat(response.getStatusCode(), is(200));
         assertThat(response.parseAsString(), is("value"));

--- a/src/test/java/nablarch/fw/web/app/MultipartAction.java
+++ b/src/test/java/nablarch/fw/web/app/MultipartAction.java
@@ -38,4 +38,16 @@ public class MultipartAction {
         String key = SessionUtil.get(context, "key");
         return new HttpResponse().write(key);
     }
+
+    /**
+     * セッションストアに値を保存する。
+     *
+     * @param request リクエスト
+     * @param context 実行コンテキスト
+     * @return レスポンス
+     */
+    public HttpResponse doPutSession(HttpRequest request, ExecutionContext context) {
+        SessionUtil.put(context, "key", "value");
+        return new HttpResponse();
+    }
 }


### PR DESCRIPTION
【原因】
セッションストアの有効期限をHTTPセッションに保持する対応により、
HTTPセッションに有効期限が存在しない場合はセッションストアが復元されなくなりました。
そのため、このテストではセッションストアから値を取得できずにエラーとなっています。

【対応】
HTTPセッションにセッションストアの有効期限を保持させるため、
事前にセッションストアを生成するリクエストを送信して、HTTPセッションに有効期限が保持されるように修正しました。
