### PR TITLE
HttpCharacterEncodingHandlerをハンドラキューに追加しテストを実施

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,14 +32,16 @@ dependencyManagement {
 
 dependencies {
   testCompile 'com.nablarch.profile:nablarch-all-in-one'
+  
+  testCompile 'com.nablarch.framework:nablarch-fw-web:1.4.2'
 
   testCompile 'org.jmockit:jmockit:1.13'
   testCompile 'junit:junit:4.12'
-  testCompile 'com.google.http-client:google-http-client:1.19.0'
+  testCompile 'com.google.http-client:google-http-client:1.22.0'
 
-  testCompile 'org.glassfish.main.extras:glassfish-embedded-all:4.1'
-  testCompile 'org.jboss.arquillian.junit:arquillian-junit-container:1.0.0.Final'
-  testCompile 'org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.CR4'
+  testCompile 'org.glassfish.main.extras:glassfish-embedded-all:4.1.2'
+  testCompile 'org.jboss.arquillian.junit:arquillian-junit-container:1.1.13.Final'
+  testCompile 'org.jboss.arquillian.container:arquillian-glassfish-embedded-3.1:1.0.0.Final'
 }
 
 task wrapper(type: Wrapper) {

--- a/src/test/resources/nablarch/fw/web/new-handler-queue-configuration.xml
+++ b/src/test/resources/nablarch/fw/web/new-handler-queue-configuration.xml
@@ -15,6 +15,7 @@
   <component name="webFrontController" class="nablarch.fw.web.servlet.WebFrontController">
     <property name="handlerQueue">
       <list>
+        <component class="nablarch.fw.web.handler.HttpCharacterEncodingHandler" />
         <component class="nablarch.fw.handler.GlobalErrorHandler"/>
         <component class="nablarch.fw.web.handler.HttpResponseHandler"/>
         <component class="nablarch.fw.web.handler.SecureHandler"/>


### PR DESCRIPTION
NAB-167対応版のnablarch-fw-webを使用することで、HttpCharacterEncodingHandlerを設定した状態でファイルアップロードが正常に処理できることを確認

NAB-167